### PR TITLE
Collapse services sharing ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.0.1
+VERSION ?= 2.0.2
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/aristanetworks/arista-ceoslab-operator

--- a/config/kustomized/manifest.yaml
+++ b/config/kustomized/manifest.yaml
@@ -487,7 +487,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/aristanetworks/arista-ceoslab-operator:v2.0.1
+        image: ghcr.io/aristanetworks/arista-ceoslab-operator:v2.0.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/aristanetworks/arista-ceoslab-operator
-  newTag: v2.0.1
+  newTag: v2.0.2

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -7,7 +7,7 @@ testDirs:
 manifestDirs:
 - config/kustomized
 kindContainers:
-- ghcr.io/aristanetworks/arista-ceoslab-operator:v2.0.1
+- ghcr.io/aristanetworks/arista-ceoslab-operator:v2.0.2
 - ceos:latest
 - ceos-2:latest
 - networkop/init-wait:latest

--- a/test/reconcile-services/01-assert.yaml
+++ b/test/reconcile-services/01-assert.yaml
@@ -41,6 +41,11 @@ spec:
     port: 25565
     protocol: TCP
     targetPort: 25565
+  - name: gnmi6030
+    port: 6030
+    protocol: TCP
+    targetPort: 6030
+    # gNOI port ignored because it's the same as gNMI
   selector:
     app: ceoslab-device
   type: LoadBalancer

--- a/test/reconcile-services/01-new-services.yaml
+++ b/test/reconcile-services/01-new-services.yaml
@@ -9,3 +9,9 @@ spec:
         - in: 22
           out: 2022
         - in: 25565
+    gnmi:
+      tcpports:
+        - in: 6030
+    gnoi:
+      tcpports:
+        - in: 6030


### PR DESCRIPTION
KNE may require you to specify different services with the same port to satisfy Ondatra. This created an issue because both gNMI and gNOI use port 6030. Now, if two services share a service, the second is just ignored.