### PR TITLE
Increase the reconcile limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 2.0.2
+VERSION ?= 2.1.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/aristanetworks/arista-ceoslab-operator

--- a/config/kustomized/manifest.yaml
+++ b/config/kustomized/manifest.yaml
@@ -487,7 +487,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/aristanetworks/arista-ceoslab-operator:v2.0.2
+        image: ghcr.io/aristanetworks/arista-ceoslab-operator:v2.1.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/aristanetworks/arista-ceoslab-operator
-  newTag: v2.0.2
+  newTag: v2.1.0

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -7,7 +7,7 @@ testDirs:
 manifestDirs:
 - config/kustomized
 kindContainers:
-- ghcr.io/aristanetworks/arista-ceoslab-operator:v2.0.2
+- ghcr.io/aristanetworks/arista-ceoslab-operator:v2.1.0
 - ceos:latest
 - ceos-2:latest
 - networkop/init-wait:latest


### PR DESCRIPTION
- Increase the reconcile limit to the number of CPUs.
- Remove globals to improve thread safety.
- Remove pedantic requeue after creating new objects. Tests make sure we create them correctly. This speeds up reconcilation further.